### PR TITLE
Spring-style caching of Session objects

### DIFF
--- a/src/main/java/de/thm/arsnova/config/ExtraConfig.java
+++ b/src/main/java/de/thm/arsnova/config/ExtraConfig.java
@@ -2,6 +2,9 @@ package de.thm.arsnova.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -16,6 +19,7 @@ import de.thm.arsnova.connector.client.ConnectorClientImpl;
 import de.thm.arsnova.socket.ARSnovaSocketIOServer;
 
 @Configuration
+@EnableCaching
 public class ExtraConfig {
 
 	@Autowired
@@ -80,5 +84,10 @@ public class ExtraConfig {
 		socketServer.setKeystore(socketKeystore);
 		socketServer.setStorepass(socketStorepass);
 		return socketServer;
+	}
+
+	@Bean
+	public CacheManager cacheManager() {
+		return new ConcurrentMapCacheManager();
 	}
 }

--- a/src/main/java/de/thm/arsnova/controller/SessionController.java
+++ b/src/main/java/de/thm/arsnova/controller/SessionController.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.token.Sha512DigestUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -67,13 +66,7 @@ public class SessionController extends AbstractController {
 
 	@RequestMapping(value = "/{sessionkey}", method = RequestMethod.GET)
 	public final Session joinSession(@PathVariable final String sessionkey) {
-		final Session session = sessionService.getSession(sessionkey);
-		if (!session.isCreator(userService.getCurrentUser())) {
-			session.setCreator("NOT VISIBLE TO YOU");
-		} else {
-			session.setCreator(Sha512DigestUtils.shaHex(session.getCreator()));
-		}
-		return session;
+		return Session.anonymizedCopy(sessionService.getSession(sessionkey));
 	}
 
 	@RequestMapping(value = "/{sessionkey}", method = RequestMethod.DELETE)

--- a/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
+++ b/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
@@ -41,6 +41,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -285,6 +288,7 @@ public class CouchDBDao implements IDatabaseDao {
 	}
 
 	@Override
+	@Cacheable("sessions")
 	public final Session getSessionFromKeyword(final String keyword) {
 		final NovaView view = new NovaView("session/by_keyword");
 		view.setKey(keyword);
@@ -300,6 +304,7 @@ public class CouchDBDao implements IDatabaseDao {
 	}
 
 	@Override
+	@Cacheable("sessions")
 	public final Session getSessionFromId(final String sessionId) {
 		final NovaView view = new NovaView("session/by_id");
 		view.setKey(sessionId);
@@ -331,6 +336,7 @@ public class CouchDBDao implements IDatabaseDao {
 		} catch (final IOException e) {
 			return null;
 		}
+		// session caching is done by loading the created session
 		return getSession(sessionDocument.getString("keyword"));
 	}
 
@@ -582,19 +588,21 @@ public class CouchDBDao implements IDatabaseDao {
 	}
 
 	@Override
-	public final void updateSessionOwnerActivity(final Session session) {
+	@CachePut(value = "sessions")
+	public final Session updateSessionOwnerActivity(final Session session) {
 		try {
 			/* Do not clutter CouchDB. Only update once every 3 hours. */
 			if (session.getLastOwnerActivity() > System.currentTimeMillis() - 3 * 3600000) {
-				return;
+				return session;
 			}
 
 			session.setLastOwnerActivity(System.currentTimeMillis());
 			final JSONObject json = JSONObject.fromObject(session);
 			getDatabase().saveDocument(new Document(json));
+			return session;
 		} catch (final IOException e) {
 			LOGGER.error("Failed to update lastOwnerActivity for Session {}", session);
-			return;
+			return session;
 		}
 	}
 
@@ -1188,6 +1196,7 @@ public class CouchDBDao implements IDatabaseDao {
 	}
 
 	@Override
+	@CachePut(value = "sessions")
 	public Session updateSession(final Session session) {
 		try {
 			final Document s = database.getDocument(session.get_id());
@@ -1206,6 +1215,7 @@ public class CouchDBDao implements IDatabaseDao {
 	}
 
 	@Override
+	@CacheEvict(value = "sessions")
 	public void deleteSession(final Session session) {
 		try {
 			deleteDocument(session.get_id());

--- a/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
+++ b/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
@@ -56,7 +56,7 @@ public interface IDatabaseDao {
 
 	LoggedIn registerAsOnlineUser(User u, Session s);
 
-	void updateSessionOwnerActivity(Session session);
+	Session updateSessionOwnerActivity(Session session);
 
 	List<String> getQuestionIds(Session session, User user);
 

--- a/src/main/java/de/thm/arsnova/entities/Session.java
+++ b/src/main/java/de/thm/arsnova/entities/Session.java
@@ -41,6 +41,27 @@ public class Session implements Serializable {
 	private String _id;
 	private String _rev;
 
+	/**
+	 * Returns a copy of the given session without any information that identifies a person.
+	 * @param original The session to create a anonymized copy of
+	 * @return
+	 */
+	public static Session anonymizedCopy(final Session original) {
+		final Session copy = new Session();
+		copy.type = original.type;
+		copy.name = original.name;
+		copy.shortName = original.shortName;
+		copy.keyword = original.keyword;
+		copy.creator = ""; // anonymous
+		copy.active = original.active;
+		copy.lastOwnerActivity = original.lastOwnerActivity;
+		copy.courseType = original.courseType;
+		copy.courseId = original.courseId;
+		copy._id = original._id;
+		copy._rev = original._rev;
+		return copy;
+	}
+
 	public String getType() {
 		return type;
 	}

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -201,9 +201,9 @@ public class StubDatabaseDao implements IDatabaseDao {
 	}
 
 	@Override
-	public void updateSessionOwnerActivity(Session session) {
+	public Session updateSessionOwnerActivity(Session session) {
 		// TODO Auto-generated method stub
-
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds cache annotations to all methods directly loading or storing a plain Session object.

In ARSnova, many, many methods first load a Session object from a given keyword, for example, to validate that the user created the Session. To reduce the amount of requests hitting the database, this PR adds Spring-style caching annotations to the CouchDBDao. Once a session object is loaded, it is put into the cache.

As you can see in the second diff, any changes to the cached objects will be visible across requests -- even if that object is not persisted! This will mean that once this PR is accepted, the Session object (or any other objects to be cached in the future) should not be changed willy-nilly or else it will have unintended side-effects.