### PR TITLE
Initial idea of a count service

### DIFF
--- a/src/main/java/de/thm/arsnova/dao/DeletionInfo.java
+++ b/src/main/java/de/thm/arsnova/dao/DeletionInfo.java
@@ -15,19 +15,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package de.thm.arsnova.services;
+package de.thm.arsnova.dao;
 
-import de.thm.arsnova.entities.Session;
+import java.util.ArrayList;
+import java.util.List;
 
-public interface CountService {
+/**
+ * Carries usable information about the documents that have been deleted from the database.
+ */
+public class DeletionInfo {
 
-	int lectureQuestionCount(final Session session);
+	private final List<String> deletedIds;
 
-	int preparationQuestionCount(final Session session);
+	public DeletionInfo(List<String> deletedIds) {
+		this.deletedIds = deletedIds;
+	}
 
-	int flashcardCount(final Session session);
+	public DeletionInfo(String id) {
+		this();
+		this.deletedIds.add(id);
+	}
 
-	int lectureQuestionAnswerCount(final Session session);
+	public DeletionInfo() {
+		this.deletedIds = new ArrayList<String>();
+	}
 
-	int preparationQuestionAnswerCount(final Session session);
+	/**
+	 * @return number of deleted documents
+	 */
+	public int count() {
+		return this.deletedIds.size();
+	}
+
 }

--- a/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
+++ b/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
@@ -19,6 +19,8 @@ package de.thm.arsnova.dao;
 
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import de.thm.arsnova.connector.model.Course;
 import de.thm.arsnova.domain.CourseScore;
 import de.thm.arsnova.entities.Answer;
@@ -74,7 +76,12 @@ public interface IDatabaseDao {
 
 	List<String> getQuestionIds(Session session, User user);
 
-	void deleteQuestionWithAnswers(Question question);
+	/**
+	 *
+	 * @param question
+	 * @return Left parameter is the deleted question, right parameter the deleted answers
+	 */
+	Pair<DeletionInfo, DeletionInfo> deleteQuestionWithAnswers(Question question);
 
 	void deleteAllQuestionsWithAnswers(Session session);
 
@@ -118,7 +125,7 @@ public interface IDatabaseDao {
 
 	Question updateQuestion(Question question);
 
-	void deleteAnswers(Question question);
+	DeletionInfo deleteAnswers(Question question);
 
 	Answer saveAnswer(Answer answer, User user, Question question, Session session);
 

--- a/src/main/java/de/thm/arsnova/events/DeleteQuestionEvent.java
+++ b/src/main/java/de/thm/arsnova/events/DeleteQuestionEvent.java
@@ -17,22 +17,36 @@
  */
 package de.thm.arsnova.events;
 
+import de.thm.arsnova.dao.DeletionInfo;
 import de.thm.arsnova.entities.Question;
 import de.thm.arsnova.entities.Session;
 
+/**
+ * This event gets fired when a question is deleted.
+ *
+ * When a question gets deleted, all associated answers are deleted as well. However, the corresponding
+ * DeleteAnswerEvents will *not* get fired.
+ */
 public class DeleteQuestionEvent extends SessionEvent {
 
 	private static final long serialVersionUID = 1L;
 
 	private final Question question;
 
-	public DeleteQuestionEvent(Object source, Session session, Question question) {
+	private final DeletionInfo deletedAnswers;
+
+	public DeleteQuestionEvent(Object source, Session session, Question question, DeletionInfo answerDeletionInfo) {
 		super(source, session);
 		this.question = question;
+		this.deletedAnswers = answerDeletionInfo;
 	}
 
 	public Question getQuestion() {
 		return this.question;
+	}
+
+	public int countDeletedAnswers() {
+		return this.deletedAnswers.count();
 	}
 
 	@Override

--- a/src/main/java/de/thm/arsnova/services/CountService.java
+++ b/src/main/java/de/thm/arsnova/services/CountService.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of ARSnova Backend.
+ * Copyright (C) 2012-2015 The ARSnova Team
+ *
+ * ARSnova Backend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ARSnova Backend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.thm.arsnova.services;
+
+import de.thm.arsnova.entities.Session;
+
+public interface CountService {
+
+	int lectureQuestionCount(final Session session);
+
+	int preparationQuestionCount(final Session session);
+
+	int flashcardCount(final Session session);
+}

--- a/src/main/java/de/thm/arsnova/services/CountService.java
+++ b/src/main/java/de/thm/arsnova/services/CountService.java
@@ -21,13 +21,13 @@ import de.thm.arsnova.entities.Session;
 
 public interface CountService {
 
-	int lectureQuestionCount(final Session session);
+	int countLectureQuestions(final Session session);
 
-	int preparationQuestionCount(final Session session);
+	int countPreparationQuestions(final Session session);
 
-	int flashcardCount(final Session session);
+	int countFlashcards(final Session session);
 
-	int lectureQuestionAnswerCount(final Session session);
+	int countLectureQuestionAnswers(final Session session);
 
-	int preparationQuestionAnswerCount(final Session session);
+	int countPreparationQuestionAnswers(final Session session);
 }

--- a/src/main/java/de/thm/arsnova/services/EventedCountService.java
+++ b/src/main/java/de/thm/arsnova/services/EventedCountService.java
@@ -1,0 +1,253 @@
+/*
+ * This file is part of ARSnova Backend.
+ * Copyright (C) 2012-2015 The ARSnova Team
+ *
+ * ARSnova Backend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ARSnova Backend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.thm.arsnova.services;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Service;
+
+import de.thm.arsnova.dao.IDatabaseDao;
+import de.thm.arsnova.entities.Question;
+import de.thm.arsnova.entities.Session;
+import de.thm.arsnova.events.ChangeLearningProgressEvent;
+import de.thm.arsnova.events.DeleteAllLectureAnswersEvent;
+import de.thm.arsnova.events.DeleteAllPreparationAnswersEvent;
+import de.thm.arsnova.events.DeleteAllQuestionsAnswersEvent;
+import de.thm.arsnova.events.DeleteAllQuestionsEvent;
+import de.thm.arsnova.events.DeleteAnswerEvent;
+import de.thm.arsnova.events.DeleteFeedbackForSessionsEvent;
+import de.thm.arsnova.events.DeleteInterposedQuestionEvent;
+import de.thm.arsnova.events.DeleteQuestionEvent;
+import de.thm.arsnova.events.DeleteSessionEvent;
+import de.thm.arsnova.events.LockQuestionEvent;
+import de.thm.arsnova.events.LockQuestionsEvent;
+import de.thm.arsnova.events.LockVotingEvent;
+import de.thm.arsnova.events.NewAnswerEvent;
+import de.thm.arsnova.events.NewFeedbackEvent;
+import de.thm.arsnova.events.NewInterposedQuestionEvent;
+import de.thm.arsnova.events.NewQuestionEvent;
+import de.thm.arsnova.events.UnlockQuestionEvent;
+import de.thm.arsnova.events.UnlockQuestionsEvent;
+import de.thm.arsnova.events.NewSessionEvent;
+import de.thm.arsnova.events.NovaEvent;
+import de.thm.arsnova.events.NovaEventVisitor;
+import de.thm.arsnova.events.PiRoundCancelEvent;
+import de.thm.arsnova.events.PiRoundDelayedStartEvent;
+import de.thm.arsnova.events.PiRoundEndEvent;
+import de.thm.arsnova.events.PiRoundResetEvent;
+import de.thm.arsnova.events.StatusSessionEvent;
+
+/**
+ * This class provides a number of methods for counting things like questions. The numbers are updated
+ * using ARSnova's internal event system.
+ */
+@Service
+public class EventedCountService implements CountService, NovaEventVisitor, ApplicationListener<NovaEvent> {
+
+	@Autowired
+	private IDatabaseDao databaseDao;
+
+	private Map<Session, Integer> lectureQuestionCount = new ConcurrentHashMap<>();
+
+	private Map<Session, Integer> preparationQuestionCount = new ConcurrentHashMap<>();
+
+	private Map<Session, Integer> flashcardCount = new ConcurrentHashMap<>();
+
+	@Override
+	public int lectureQuestionCount(final Session session) {
+		if (!lectureQuestionCount.containsKey(session)) {
+			int count = databaseDao.getLectureQuestionCount(session);
+			lectureQuestionCount.put(session, count);
+		}
+		return lectureQuestionCount.get(session);
+	}
+
+	@Override
+	public int preparationQuestionCount(final Session session) {
+		if (!preparationQuestionCount.containsKey(session)) {
+			int count = databaseDao.getPreparationQuestionCount(session);
+			preparationQuestionCount.put(session, count);
+		}
+		return preparationQuestionCount.get(session);
+	}
+
+	@Override
+	public int flashcardCount(final Session session) {
+		if (!flashcardCount.containsKey(session)) {
+			int count = databaseDao.getFlashcardCount(session);
+			flashcardCount.put(session, count);
+		}
+		return flashcardCount.get(session);
+	}
+
+	@Override
+	public void visit(NewInterposedQuestionEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteInterposedQuestionEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(NewQuestionEvent event) {
+		final Question q = event.getQuestion();
+		final Session s = event.getSession();
+		if (q.getQuestionVariant().equals("lecture")) {
+			if (lectureQuestionCount.containsKey(s)) {
+				int count = lectureQuestionCount.get(s);
+				lectureQuestionCount.put(s, count+1);
+			}
+		} else if (q.getQuestionVariant().equals("preparation")) {
+			if (preparationQuestionCount.containsKey(s)) {
+				int count = preparationQuestionCount.get(s);
+				preparationQuestionCount.put(s, count+1);
+			}
+		} else if (q.getQuestionVariant().equals("flashcard")) {
+			if (flashcardCount.containsKey(s)) {
+				int count = flashcardCount.get(s);
+				flashcardCount.put(s, count+1);
+			}
+		}
+	}
+
+	@Override
+	public void visit(DeleteQuestionEvent event) {
+		final Question q = event.getQuestion();
+		final Session s = event.getSession();
+		if (q.getQuestionVariant().equals("lecture")) {
+			if (lectureQuestionCount.containsKey(s)) {
+				int count = lectureQuestionCount.get(s);
+				lectureQuestionCount.put(s, count-1);
+			}
+		} else if (q.getQuestionVariant().equals("preparation")) {
+			if (preparationQuestionCount.containsKey(s)) {
+				int count = preparationQuestionCount.get(s);
+				preparationQuestionCount.put(s, count-1);
+			}
+		} else if (q.getQuestionVariant().equals("flashcard")) {
+			if (flashcardCount.containsKey(s)) {
+				int count = flashcardCount.get(s);
+				flashcardCount.put(s, count-1);
+			}
+		}
+	}
+
+	@Override
+	public void visit(DeleteAllQuestionsEvent event) {
+		final Session s = event.getSession();
+		lectureQuestionCount.put(s, 0);
+		preparationQuestionCount.put(s, 0);
+		flashcardCount.put(s, 0);
+	}
+
+	@Override
+	public void visit(UnlockQuestionEvent event) {
+		// TODO Use for role-specific counting
+	}
+
+	@Override
+	public void visit(UnlockQuestionsEvent event) {
+		// TODO Use for role-specific counting
+	}
+
+	@Override
+	public void visit(LockQuestionEvent event) {
+		// TODO Use for role-specific counting
+	}
+
+	@Override
+	public void visit(LockQuestionsEvent event) {
+		// TODO Use for role-specific counting
+	}
+
+	@Override
+	public void visit(NewAnswerEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteAnswerEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteAllQuestionsAnswersEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteAllPreparationAnswersEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteAllLectureAnswersEvent event) {
+		// TODO: Future use
+	}
+
+	@Override
+	public void visit(DeleteSessionEvent event) {
+		final Session s = event.getSession();
+		lectureQuestionCount.remove(s);
+		preparationQuestionCount.remove(s);
+		flashcardCount.remove(s);
+	}
+
+	// Unused events
+
+	@Override
+	public void visit(NewFeedbackEvent event) {}
+
+	@Override
+	public void visit(DeleteFeedbackForSessionsEvent event) {}
+
+	@Override
+	public void visit(StatusSessionEvent event) {}
+
+	@Override
+	public void visit(ChangeLearningProgressEvent event) {}
+
+	@Override
+	public void visit(PiRoundDelayedStartEvent event) {}
+
+	@Override
+	public void visit(PiRoundEndEvent event) {}
+
+	@Override
+	public void visit(PiRoundCancelEvent event) {}
+
+	@Override
+	public void visit(PiRoundResetEvent event) {}
+
+	@Override
+	public void visit(NewSessionEvent event) {}
+
+	@Override
+	public void visit(LockVotingEvent event) {}
+
+	@Override
+	public void onApplicationEvent(NovaEvent event) {
+		event.accept(this);
+	}
+
+}

--- a/src/main/java/de/thm/arsnova/services/EventedCountService.java
+++ b/src/main/java/de/thm/arsnova/services/EventedCountService.java
@@ -76,7 +76,7 @@ public class EventedCountService implements CountService, NovaEventVisitor, Appl
 	private Map<Session, Integer> preparationQuestionAnswerCount = new ConcurrentHashMap<>();
 
 	@Override
-	public int lectureQuestionCount(final Session session) {
+	public int countLectureQuestions(final Session session) {
 		if (!lectureQuestionCount.containsKey(session)) {
 			int count = databaseDao.getLectureQuestionCount(session);
 			lectureQuestionCount.put(session, count);
@@ -85,7 +85,7 @@ public class EventedCountService implements CountService, NovaEventVisitor, Appl
 	}
 
 	@Override
-	public int preparationQuestionCount(final Session session) {
+	public int countPreparationQuestions(final Session session) {
 		if (!preparationQuestionCount.containsKey(session)) {
 			int count = databaseDao.getPreparationQuestionCount(session);
 			preparationQuestionCount.put(session, count);
@@ -94,7 +94,7 @@ public class EventedCountService implements CountService, NovaEventVisitor, Appl
 	}
 
 	@Override
-	public int flashcardCount(final Session session) {
+	public int countFlashcards(final Session session) {
 		if (!flashcardCount.containsKey(session)) {
 			int count = databaseDao.getFlashcardCount(session);
 			flashcardCount.put(session, count);
@@ -103,7 +103,7 @@ public class EventedCountService implements CountService, NovaEventVisitor, Appl
 	}
 
 	@Override
-	public int lectureQuestionAnswerCount(final Session session) {
+	public int countLectureQuestionAnswers(final Session session) {
 		if (!lectureQuestionAnswerCount.containsKey(session)) {
 			int count = databaseDao.countLectureQuestionAnswers(session);
 			lectureQuestionAnswerCount.put(session, count);
@@ -112,7 +112,7 @@ public class EventedCountService implements CountService, NovaEventVisitor, Appl
 	}
 
 	@Override
-	public int preparationQuestionAnswerCount(final Session session) {
+	public int countPreparationQuestionAnswers(final Session session) {
 		if (!preparationQuestionAnswerCount.containsKey(session)) {
 			int count = databaseDao.countPreparationQuestionAnswers(session);
 			preparationQuestionAnswerCount.put(session, count);

--- a/src/main/java/de/thm/arsnova/services/QuestionService.java
+++ b/src/main/java/de/thm/arsnova/services/QuestionService.java
@@ -83,6 +83,9 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	@Autowired
 	private ImageUtils imageUtils;
 
+	@Autowired
+	private CountService countService;
+
 	@Value("${upload.filesize_b}")
 	private int uploadFileSizeByte;
 
@@ -785,19 +788,19 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getLectureQuestionCount(final String sessionkey) {
-		return databaseDao.getLectureQuestionCount(getSession(sessionkey));
+		return countService.lectureQuestionCount(getSession(sessionkey));
 	}
 
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getFlashcardCount(final String sessionkey) {
-		return databaseDao.getFlashcardCount(getSession(sessionkey));
+		return countService.flashcardCount(getSession(sessionkey));
 	}
 
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getPreparationQuestionCount(final String sessionkey) {
-		return databaseDao.getPreparationQuestionCount(getSession(sessionkey));
+		return countService.preparationQuestionCount(getSession(sessionkey));
 	}
 
 	@Override

--- a/src/main/java/de/thm/arsnova/services/QuestionService.java
+++ b/src/main/java/de/thm/arsnova/services/QuestionService.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import de.thm.arsnova.ImageUtils;
+import de.thm.arsnova.dao.DeletionInfo;
 import de.thm.arsnova.dao.IDatabaseDao;
 import de.thm.arsnova.entities.Answer;
 import de.thm.arsnova.entities.InterposedQuestion;
@@ -222,9 +224,9 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 			throw new UnauthorizedException();
 		}
 		deleteQuestionFromSortOrder(question);
-		databaseDao.deleteQuestionWithAnswers(question);
+		Pair<DeletionInfo, DeletionInfo> pair = databaseDao.deleteQuestionWithAnswers(question);
 
-		final DeleteQuestionEvent event = new DeleteQuestionEvent(this, session, question);
+		final DeleteQuestionEvent event = new DeleteQuestionEvent(this, session, question, pair.getRight());
 		this.publisher.publishEvent(event);
 	}
 
@@ -815,7 +817,7 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	 */
 	@Override
 	public int countLectureQuestionAnswersInternal(final String sessionkey) {
-		return databaseDao.countLectureQuestionAnswers(getSession(sessionkey));
+		return countService.lectureQuestionAnswerCount(getSession(sessionkey));
 	}
 
 	@Override
@@ -846,7 +848,7 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	 */
 	@Override
 	public int countPreparationQuestionAnswersInternal(final String sessionkey) {
-		return databaseDao.countPreparationQuestionAnswers(getSession(sessionkey));
+		return countService.preparationQuestionAnswerCount(getSession(sessionkey));
 	}
 
 	@Override

--- a/src/main/java/de/thm/arsnova/services/QuestionService.java
+++ b/src/main/java/de/thm/arsnova/services/QuestionService.java
@@ -343,7 +343,7 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 		} else {
 			databaseDao.updateQuestion(question);
 		}
-		
+
 		this.publisher.publishEvent(new LockVotingEvent(this, session, question));
 	}
 
@@ -790,19 +790,19 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getLectureQuestionCount(final String sessionkey) {
-		return countService.lectureQuestionCount(getSession(sessionkey));
+		return countService.countLectureQuestions(getSession(sessionkey));
 	}
 
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getFlashcardCount(final String sessionkey) {
-		return countService.flashcardCount(getSession(sessionkey));
+		return countService.countFlashcards(getSession(sessionkey));
 	}
 
 	@Override
 	@PreAuthorize("isAuthenticated()")
 	public int getPreparationQuestionCount(final String sessionkey) {
-		return countService.preparationQuestionCount(getSession(sessionkey));
+		return countService.countPreparationQuestionAnswers(getSession(sessionkey));
 	}
 
 	@Override
@@ -817,7 +817,7 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	 */
 	@Override
 	public int countLectureQuestionAnswersInternal(final String sessionkey) {
-		return countService.lectureQuestionAnswerCount(getSession(sessionkey));
+		return countService.countLectureQuestionAnswers(getSession(sessionkey));
 	}
 
 	@Override
@@ -848,7 +848,7 @@ public class QuestionService implements IQuestionService, ApplicationEventPublis
 	 */
 	@Override
 	public int countPreparationQuestionAnswersInternal(final String sessionkey) {
-		return countService.preparationQuestionAnswerCount(getSession(sessionkey));
+		return countService.countPreparationQuestionAnswers(getSession(sessionkey));
 	}
 
 	@Override

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import de.thm.arsnova.connector.model.Course;
 import de.thm.arsnova.domain.CourseScore;
 import de.thm.arsnova.entities.Answer;
@@ -284,13 +286,15 @@ public class StubDatabaseDao implements IDatabaseDao {
 	}
 
 	@Override
-	public void deleteQuestionWithAnswers(Question question) {
+	public Pair<DeletionInfo, DeletionInfo> deleteQuestionWithAnswers(Question question) {
 		// TODO Auto-generated method stub
+		return null;
 	}
 
 	@Override
-	public void deleteAnswers(Question question) {
+	public DeletionInfo deleteAnswers(Question question) {
 		// TODO Auto-generated method stub
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
This new service should keep the number of questions up to date without hitting the CouchDB every time. The idea is to fetch the initial numbers only once from the database, and then to keep it updated using ARSnova's internal events such as `NewQuestionEvent`.

Currently, it only counts the total number of questions according to their variant, but this could be extended to the number of answers and even to the number of unanswered questions per user.

What are your thoughts on this? As I see it, this is a major opportunity to reduce CouchDB's load with minimum effort.

Note: While this PR is mergeable, it's effects are minimal because the implemented count methods are not used very much. Additionally, there is quite some repetition since I put this together mainly as a proof of concept. Concurrency is also an issue. My goal is to update this PR over time and finally merge it once we fleshed things out a bit further.