### PR TITLE
Implement handling of interposed questions with Couchbase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,14 @@
 			<name>Sonatype Snapshot Repository</name>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>http://files.couchbase.com/maven2</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<dependencyManagement>
@@ -173,6 +181,11 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-ldap</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-couchbase</artifactId>
+			<version>2.0.0.M1</version>
 		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>

--- a/src/main/java/de/thm/arsnova/config/CouchbaseConfig.java
+++ b/src/main/java/de/thm/arsnova/config/CouchbaseConfig.java
@@ -1,0 +1,38 @@
+package de.thm.arsnova.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration;
+import org.springframework.data.couchbase.core.view.Consistency;
+
+@Configuration
+public class CouchbaseConfig extends AbstractCouchbaseConfiguration {
+
+	@Value(value = "${couchbase.host}") private String host;
+	@Value(value = "${couchbase.bucketName}") private String bucketName;
+	@Value(value = "${couchbase.bucketPassword}") private String bucketPassword;
+
+	@Override
+	protected List<String> getBootstrapHosts() {
+		return Collections.singletonList(this.host);
+	}
+
+	@Override
+	protected String getBucketName() {
+		return this.bucketName;
+	}
+
+	@Override
+	protected String getBucketPassword() {
+		return this.bucketPassword;
+	}
+
+	@Override
+	protected Consistency getDefaultConsistency() {
+		return Consistency.STRONGLY_CONSISTENT;
+	}
+
+}

--- a/src/main/java/de/thm/arsnova/config/ExtraConfig.java
+++ b/src/main/java/de/thm/arsnova/config/ExtraConfig.java
@@ -17,11 +17,6 @@
  */
 package de.thm.arsnova.config;
 
-import de.thm.arsnova.ImageUtils;
-import de.thm.arsnova.connector.client.ConnectorClient;
-import de.thm.arsnova.connector.client.ConnectorClientImpl;
-import de.thm.arsnova.socket.ARSnovaSocket;
-import de.thm.arsnova.socket.ARSnovaSocketIOServer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
@@ -36,9 +31,15 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import de.thm.arsnova.ImageUtils;
+import de.thm.arsnova.connector.client.ConnectorClient;
+import de.thm.arsnova.connector.client.ConnectorClientImpl;
+import de.thm.arsnova.socket.ARSnovaSocket;
+import de.thm.arsnova.socket.ARSnovaSocketIOServer;
 
 /**
  * Loads property file and configures non-security related beans and components.
@@ -46,6 +47,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @EnableWebMvc
 @Configuration
 @EnableCaching
+@EnableCouchbaseRepositories("de.thm.arsnova.repositories")
 public class ExtraConfig extends WebMvcConfigurerAdapter {
 
 	@Autowired

--- a/src/main/java/de/thm/arsnova/controller/AudienceQuestionController.java
+++ b/src/main/java/de/thm/arsnova/controller/AudienceQuestionController.java
@@ -17,17 +17,14 @@
  */
 package de.thm.arsnova.controller;
 
-import de.thm.arsnova.entities.InterposedReadingCount;
-import de.thm.arsnova.entities.transport.InterposedQuestion;
-import de.thm.arsnova.exceptions.BadRequestException;
-import de.thm.arsnova.services.IQuestionService;
-import de.thm.arsnova.web.DeprecatedApi;
-import de.thm.arsnova.web.Pagination;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +37,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import de.thm.arsnova.entities.InterposedReadingCount;
+import de.thm.arsnova.entities.transport.InterposedQuestion;
+import de.thm.arsnova.exceptions.BadRequestException;
+import de.thm.arsnova.services.IQuestionService;
+import de.thm.arsnova.web.DeprecatedApi;
+import de.thm.arsnova.web.Pagination;
 
 /**
  * Handles requests related to audience questions, which are also called interposed or feedback questions.
@@ -54,15 +56,6 @@ public class AudienceQuestionController extends PaginationController {
 
 	@Autowired
 	private IQuestionService questionService;
-
-	@ApiOperation(value = "Count all the questions in current session",
-			nickname = "getAudienceQuestionCount")
-	@RequestMapping(value = "/count", method = RequestMethod.GET)
-	@DeprecatedApi
-	@Deprecated
-	public int getInterposedCount(@ApiParam(value = "Session-Key from current session", required = true) @RequestParam final String sessionkey) {
-		return questionService.getInterposedCount(sessionkey);
-	}
 
 	@ApiOperation(value = "count all unread interposed questions",
 			nickname = "getUnreadInterposedCount")
@@ -96,10 +89,10 @@ public class AudienceQuestionController extends PaginationController {
 	@RequestMapping(value = "/", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public void postInterposedQuestion(
-			@ApiParam(value = "Session-Key from current session", required = true) @RequestParam final String sessionkey,
-			@ApiParam(value = "the body from the new question", required = true) @RequestBody final de.thm.arsnova.entities.InterposedQuestion question
+			@ApiParam(value="Session-Key from current session", required=true) @RequestParam final String sessionkey,
+			@ApiParam(value="the body from the new question", required=true) @RequestBody final de.thm.arsnova.entities.transport.InterposedQuestion question
 			) {
-		if (questionService.saveQuestion(question)) {
+		if (questionService.saveQuestion(question.toEntity(sessionkey))) {
 			return;
 		}
 

--- a/src/main/java/de/thm/arsnova/controller/LegacyController.java
+++ b/src/main/java/de/thm/arsnova/controller/LegacyController.java
@@ -102,18 +102,6 @@ public class LegacyController extends AbstractController {
 		questionService.deleteAllInterposedQuestions(sessionKey);
 	}
 
-	@DeprecatedApi
-	@RequestMapping(value = "/session/{sessionKey}/interposedcount", method = RequestMethod.GET)
-	public String redirectQuestionByAudienceCount(@PathVariable final String sessionKey) {
-		return String.format("forward:/audiencequestion/count?sessionkey=%s", sessionKey);
-	}
-
-	@DeprecatedApi
-	@RequestMapping(value = "/session/{sessionKey}/interposedreadingcount", method = RequestMethod.GET)
-	public String redirectQuestionByAudienceReadCount(@PathVariable final String sessionKey) {
-		return String.format("forward:/audiencequestion/readcount?sessionkey=%s", sessionKey);
-	}
-
 	/* generalized routes */
 
 	@DeprecatedApi

--- a/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
+++ b/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
@@ -689,7 +689,7 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 		q.put("creator", user.getUsername());
 		try {
 			database.saveDocument(q);
-			question.set_id(q.getId());
+			question.setId(q.getId());
 			question.set_rev(q.getRev());
 
 			return question;
@@ -1086,23 +1086,6 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 	}
 
 	@Override
-	public int getInterposedCount(final String sessionKey) {
-		final Session s = getDatabaseDao().getSessionFromKeyword(sessionKey);
-		if (s == null) {
-			throw new NotFoundException();
-		}
-
-		final NovaView view = new NovaView("interposed_question/count_by_session");
-		view.setKey(s.get_id());
-		view.setGroup(true);
-		final ViewResults results = getDatabase().view(view);
-		if (results.size() == 0 || results.getResults().size() == 0) {
-			return 0;
-		}
-		return results.getJSONArray("rows").optJSONObject(0).optInt("value");
-	}
-
-	@Override
 	public InterposedReadingCount getInterposedReadingCount(final Session session) {
 		final NovaView view = new NovaView("interposed_question/count_by_session_reading");
 		view.setStartKeyArray(session.get_id());
@@ -1211,7 +1194,7 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 					InterposedQuestion.class
 					);
 			question.setSessionId(session.getKeyword());
-			question.set_id(document.getId());
+			question.setId(document.getId());
 			result.add(question);
 		}
 		return result;
@@ -1306,11 +1289,11 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 	public void markInterposedQuestionAsRead(final InterposedQuestion question) {
 		try {
 			question.setRead(true);
-			final Document document = getDatabase().getDocument(question.get_id());
+			final Document document = getDatabase().getDocument(question.getId());
 			document.put("read", question.isRead());
 			getDatabase().saveDocument(document);
 		} catch (final IOException e) {
-			LOGGER.error("Coulg not mark interposed question as read {}", question.get_id());
+			LOGGER.error("Coulg not mark interposed question as read {}", question.getId());
 		}
 	}
 
@@ -1481,9 +1464,9 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 	@Override
 	public void deleteInterposedQuestion(final InterposedQuestion question) {
 		try {
-			deleteDocument(question.get_id());
+			deleteDocument(question.getId());
 		} catch (final IOException e) {
-			LOGGER.error("Could not delete interposed question {} because of {}", question.get_id(), e.getMessage());
+			LOGGER.error("Could not delete interposed question {} because of {}", question.getId(), e.getMessage());
 		}
 	}
 

--- a/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
+++ b/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
@@ -105,8 +105,6 @@ public interface IDatabaseDao {
 
 	int getTotalAnswerCount(String sessionKey);
 
-	int getInterposedCount(String sessionKey);
-
 	InterposedReadingCount getInterposedReadingCount(Session session);
 
 	InterposedReadingCount getInterposedReadingCount(Session session, User user);

--- a/src/main/java/de/thm/arsnova/entities/InterposedQuestion.java
+++ b/src/main/java/de/thm/arsnova/entities/InterposedQuestion.java
@@ -17,11 +17,14 @@
  */
 package de.thm.arsnova.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.Serializable;
+
+import org.springframework.data.annotation.Id;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * A question the user is asking the teacher. Also known as feedback or audience question.
@@ -29,9 +32,10 @@ import java.io.Serializable;
 @ApiModel(value = "audiencequestion", description = "the interposed question entity")
 public class InterposedQuestion implements Serializable {
 
-	private String _id;
+	@Id
+	private String id;
 	private String _rev;
-	private String type;
+	private String type = "interposed_question";
 	private String subject;
 	private String text;
 	/* FIXME sessionId actually is used to hold the sessionKey.
@@ -40,16 +44,17 @@ public class InterposedQuestion implements Serializable {
 	 * refactoring since the client application depends on the
 	 * current naming */
 	private String sessionId;
+	private Session session;
 	private long timestamp;
 	private boolean read;
 	private String creator;
 
 	@ApiModelProperty(required = true, value = "the couchDB ID")
-	public String get_id() {
-		return _id;
+	public String getId() {
+		return id;
 	}
-	public void set_id(String _id) {
-		this._id = _id;
+	public void setId(String _id) {
+		this.id = _id;
 	}
 
 	public String get_rev() {

--- a/src/main/java/de/thm/arsnova/entities/InterposedReadingCount.java
+++ b/src/main/java/de/thm/arsnova/entities/InterposedReadingCount.java
@@ -26,10 +26,10 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(value = "audiencequestion/readcount", description = "the interposed reading count entity")
 public class InterposedReadingCount {
 
-	private int read;
-	private int unread;
+	private long read;
+	private long unread;
 
-	public InterposedReadingCount(int readCount, int unreadCount) {
+	public InterposedReadingCount(long readCount, long unreadCount) {
 		this.read = readCount;
 		this.unread = unreadCount;
 	}
@@ -40,16 +40,16 @@ public class InterposedReadingCount {
 	}
 
 	@ApiModelProperty(required = true, value = "the number of read interposed questions")
-	public int getRead() {
+	public long getRead() {
 		return read;
 	}
 
-	public void setRead(int read) {
+	public void setRead(long read) {
 		this.read = read;
 	}
 
 	@ApiModelProperty(required = true, value = "the number of unread interposed questions")
-	public int getUnread() {
+	public long getUnread() {
 		return unread;
 	}
 
@@ -58,7 +58,7 @@ public class InterposedReadingCount {
 	}
 
 	@ApiModelProperty(required = true, value = "the number of total interposed questions")
-	public int getTotal() {
+	public long getTotal() {
 		return getRead() + getUnread();
 	}
 }

--- a/src/main/java/de/thm/arsnova/entities/transport/InterposedQuestion.java
+++ b/src/main/java/de/thm/arsnova/entities/transport/InterposedQuestion.java
@@ -44,7 +44,7 @@ public class InterposedQuestion {
 	}
 
 	public InterposedQuestion(de.thm.arsnova.entities.InterposedQuestion question) {
-		this.id = question.get_id();
+		this.id = question.getId();
 		this.subject = question.getSubject();
 		this.text = question.getText();
 		this.timestamp = question.getTimestamp();
@@ -52,6 +52,17 @@ public class InterposedQuestion {
 	}
 
 	public InterposedQuestion() { }
+
+	public de.thm.arsnova.entities.InterposedQuestion toEntity(String sessionKey) {
+		de.thm.arsnova.entities.InterposedQuestion entity = new de.thm.arsnova.entities.InterposedQuestion();
+		entity.setId(this.getId());
+		entity.setSubject(this.getSubject());
+		entity.setText(this.getText());
+		entity.setTimestamp(this.getTimestamp());
+		entity.setSessionId(sessionKey);
+		entity.setRead(this.isRead());
+		return entity;
+	}
 
 	@ApiModelProperty(required = true, value = "used to display Id")
 	public String getId() {

--- a/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepository.java
+++ b/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepository.java
@@ -1,0 +1,22 @@
+package de.thm.arsnova.repositories;
+
+import java.util.List;
+
+import org.springframework.data.couchbase.core.view.Query;
+import org.springframework.data.couchbase.repository.CouchbaseRepository;
+
+import de.thm.arsnova.entities.InterposedQuestion;
+
+/**
+ * Handles all database operations on interposed questions.
+ */
+public interface InterposedQuestionRepository extends CouchbaseRepository<InterposedQuestion, String>,
+		InterposedQuestionRepositoryCustom {
+
+	@Query("$SELECT_ENTITY$ WHERE sessionId = $1 AND $FILTER_TYPE$")
+	public List<InterposedQuestion> findBySession(String sessionId);
+
+	@Query("$SELECT_ENTITY$ WHERE sessionId = $1 AND creator = $2 AND $FILTER_TYPE$")
+	public List<InterposedQuestion> findBySessionAndCreator(String sessionId, String creator);
+
+}

--- a/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepositoryCustom.java
+++ b/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepositoryCustom.java
@@ -1,0 +1,16 @@
+package de.thm.arsnova.repositories;
+
+import de.thm.arsnova.entities.InterposedReadingCount;
+import de.thm.arsnova.entities.Session;
+import de.thm.arsnova.entities.User;
+
+/**
+ * Custom interface to allow view-based repository methods with complex keys.
+ */
+public interface InterposedQuestionRepositoryCustom {
+
+	public InterposedReadingCount countReadingBySessionAndCreator(Session session, User creator);
+
+	public InterposedReadingCount countReadingBySession(Session session);
+
+}

--- a/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepositoryImpl.java
+++ b/src/main/java/de/thm/arsnova/repositories/InterposedQuestionRepositoryImpl.java
@@ -1,0 +1,67 @@
+package de.thm.arsnova.repositories;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.couchbase.core.CouchbaseOperations;
+
+import com.couchbase.client.java.document.json.JsonArray;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.view.ViewQuery;
+import com.couchbase.client.java.view.ViewResult;
+import com.couchbase.client.java.view.ViewRow;
+
+import de.thm.arsnova.entities.InterposedReadingCount;
+import de.thm.arsnova.entities.Session;
+import de.thm.arsnova.entities.User;
+
+/**
+ * View-based implementation of repository for interposed questions.
+ */
+public class InterposedQuestionRepositoryImpl implements InterposedQuestionRepositoryCustom {
+
+	private static final String DESIGN_DOCUMENT = "interposedquestion";
+
+	@Autowired
+	private CouchbaseOperations ops;
+
+	@Override
+	public InterposedReadingCount countReadingBySessionAndCreator(Session session, User creator) {
+		ViewQuery query = ViewQuery.from(DESIGN_DOCUMENT, "count_by_session_reading_for_creator")
+		.startKey(JsonArray.from(session.get_id(), creator.getUsername()))
+		.endKey(JsonArray.from(session.get_id(), creator.getUsername(), JsonObject.empty()))
+		.reduce()
+		.group();
+
+		return executeReadingView(query);
+	}
+
+	@Override
+	public InterposedReadingCount countReadingBySession(Session session) {
+		ViewQuery query = ViewQuery.from(DESIGN_DOCUMENT, "count_by_session_reading_for_creator")
+		.startKey(JsonArray.from(session.get_id()))
+		.endKey(JsonArray.from(session.get_id(), JsonObject.empty()))
+		.reduce()
+		.group();
+
+		return executeReadingView(query);
+	}
+
+	private InterposedReadingCount executeReadingView(ViewQuery query) {
+		ViewResult response = ops.queryView(query);
+		if (!response.success()) {
+			return new InterposedReadingCount();
+		}
+
+		long readCount = 0;
+		long unreadCount = 0;
+		for (ViewRow row : response) {
+			JsonArray key = (JsonArray) row.key();
+			long value = Long.parseLong(row.value().toString());
+			if (key.get(2).equals("unread")) {
+				unreadCount += value;
+			} else {
+				readCount += value;
+			}
+		}
+		return new InterposedReadingCount(readCount, unreadCount);
+	}
+}

--- a/src/main/java/de/thm/arsnova/security/ApplicationPermissionEvaluator.java
+++ b/src/main/java/de/thm/arsnova/security/ApplicationPermissionEvaluator.java
@@ -17,13 +17,9 @@
  */
 package de.thm.arsnova.security;
 
-import com.github.leleuj.ss.oauth.client.authentication.OAuthAuthenticationToken;
-import de.thm.arsnova.dao.IDatabaseDao;
-import de.thm.arsnova.entities.InterposedQuestion;
-import de.thm.arsnova.entities.Question;
-import de.thm.arsnova.entities.Session;
-import de.thm.arsnova.entities.User;
-import de.thm.arsnova.exceptions.UnauthorizedException;
+import java.io.Serializable;
+import java.util.Arrays;
+
 import org.scribe.up.profile.facebook.FacebookProfile;
 import org.scribe.up.profile.google.Google2Profile;
 import org.scribe.up.profile.twitter.TwitterProfile;
@@ -35,8 +31,15 @@ import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
-import java.io.Serializable;
-import java.util.Arrays;
+import com.github.leleuj.ss.oauth.client.authentication.OAuthAuthenticationToken;
+
+import de.thm.arsnova.dao.IDatabaseDao;
+import de.thm.arsnova.entities.InterposedQuestion;
+import de.thm.arsnova.entities.Question;
+import de.thm.arsnova.entities.Session;
+import de.thm.arsnova.entities.User;
+import de.thm.arsnova.exceptions.UnauthorizedException;
+import de.thm.arsnova.repositories.InterposedQuestionRepository;
 
 /**
  * Provides access control methods that can be used in annotations.
@@ -50,6 +53,9 @@ public class ApplicationPermissionEvaluator implements PermissionEvaluator {
 
 	@Autowired
 	private IDatabaseDao dao;
+
+	@Autowired
+	private InterposedQuestionRepository interposedRepository;
 
 	@Override
 	public boolean hasPermission(
@@ -141,7 +147,7 @@ public class ApplicationPermissionEvaluator implements PermissionEvaluator {
 			final Object permission
 			) {
 		if (permission instanceof String && permission.equals("owner")) {
-			final InterposedQuestion question = dao.getInterposedQuestion(targetId.toString());
+			final InterposedQuestion question = interposedRepository.findOne(targetId.toString());
 			if (question != null) {
 				// Does the creator want to delete his own question?
 				if (question.getCreator() != null && question.getCreator().equals(username)) {

--- a/src/main/java/de/thm/arsnova/services/IQuestionService.java
+++ b/src/main/java/de/thm/arsnova/services/IQuestionService.java
@@ -79,8 +79,6 @@ public interface IQuestionService {
 
 	int getTotalAnswerCountByQuestion(String questionId);
 
-	int getInterposedCount(String sessionKey);
-
 	InterposedReadingCount getInterposedReadingCount(String sessionKey, String username);
 
 	List<InterposedQuestion> getInterposedQuestions(String sessionKey, int offset, int limit);

--- a/src/main/java/de/thm/arsnova/socket/ARSnovaSocketIOServer.java
+++ b/src/main/java/de/thm/arsnova/socket/ARSnovaSocketIOServer.java
@@ -416,7 +416,7 @@ public class ARSnovaSocketIOServer implements ARSnovaSocket, NovaEventVisitor {
 
 	public void reportAudienceQuestionAvailable(final de.thm.arsnova.entities.Session session, final InterposedQuestion audienceQuestion) {
 		/* TODO role handling implementation, send this only to users with role lecturer */
-		broadcastInSession(session.getKeyword(), "audQuestionAvail", audienceQuestion.get_id());
+		broadcastInSession(session.getKeyword(), "audQuestionAvail", audienceQuestion.getId());
 	}
 
 	public void reportLecturerQuestionAvailable(final de.thm.arsnova.entities.Session session, final List<de.thm.arsnova.entities.Question> qs) {

--- a/src/main/resources/arsnova.properties.example
+++ b/src/main/resources/arsnova.properties.example
@@ -39,6 +39,9 @@ couchdb.name=arsnova
 couchdb.username=admin
 couchdb.password=
 
+couchbase.host=localhost
+couchbase.bucketName=arsnova
+couchbase.bucketPassword=
 
 ################################################################################
 # E-Mail

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -229,12 +229,6 @@ public class StubDatabaseDao implements IDatabaseDao {
 	}
 
 	@Override
-	public int getInterposedCount(String sessionKey) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
 	public List<InterposedQuestion> getInterposedQuestions(Session session, final int start, final int limit) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -298,8 +298,7 @@ public class StubDatabaseDao implements IDatabaseDao {
 
 	@Override
 	public Session getSessionFromId(String sessionId) {
-		// TODO Auto-generated method stub
-		return null;
+		return stubSessions.get(sessionId);
 	}
 
 	@Override

--- a/src/test/java/de/thm/arsnova/repositories/StubInterposedQuestionRepository.java
+++ b/src/test/java/de/thm/arsnova/repositories/StubInterposedQuestionRepository.java
@@ -1,0 +1,104 @@
+package de.thm.arsnova.repositories;
+
+import java.util.List;
+
+import de.thm.arsnova.entities.InterposedQuestion;
+import de.thm.arsnova.entities.InterposedReadingCount;
+import de.thm.arsnova.entities.Session;
+import de.thm.arsnova.entities.User;
+
+public class StubInterposedQuestionRepository implements InterposedQuestionRepository {
+
+	public InterposedQuestion interposedQuestion;
+
+	@Override
+	public long count() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public void delete(String arg0) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void delete(InterposedQuestion arg0) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void delete(Iterable<? extends InterposedQuestion> arg0) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void deleteAll() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public boolean exists(String arg0) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public Iterable<InterposedQuestion> findAll() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Iterable<InterposedQuestion> findAll(Iterable<String> arg0) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public InterposedQuestion findOne(String arg0) {
+		return this.interposedQuestion;
+	}
+
+	@Override
+	public <S extends InterposedQuestion> S save(S arg0) {
+		return arg0;
+	}
+
+	@Override
+	public <S extends InterposedQuestion> Iterable<S> save(Iterable<S> arg0) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public InterposedReadingCount countReadingBySessionAndCreator(
+			Session session, User creator) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public InterposedReadingCount countReadingBySession(Session session) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<InterposedQuestion> findBySession(String sessionId) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<InterposedQuestion> findBySessionAndCreator(String sessionId,
+			String creator) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/test/java/de/thm/arsnova/services/QuestionServiceTest.java
+++ b/src/test/java/de/thm/arsnova/services/QuestionServiceTest.java
@@ -106,11 +106,11 @@ public class QuestionServiceTest {
 		setAuthenticated(true, "ptsr00");
 		final InterposedQuestion theQ = new InterposedQuestion();
 		theQ.setRead(false);
-		theQ.set_id("the internal id");
+		theQ.setId("the internal id");
 		theQ.setSessionId("12345678");
 		databaseDao.interposedQuestion = theQ;
 
-		questionService.readInterposedQuestion(theQ.get_id());
+		questionService.readInterposedQuestion(theQ.getId());
 
 		assertTrue(theQ.isRead());
 	}
@@ -120,12 +120,12 @@ public class QuestionServiceTest {
 		setAuthenticated(true, "regular user");
 		final InterposedQuestion theQ = new InterposedQuestion();
 		theQ.setRead(false);
-		theQ.set_id("the internal id");
+		theQ.setId("the internal id");
 		theQ.setSessionId("12345678");
 		theQ.setCreator("regular user");
 		databaseDao.interposedQuestion = theQ;
 
-		questionService.readInterposedQuestion(theQ.get_id());
+		questionService.readInterposedQuestion(theQ.getId());
 
 		assertFalse(theQ.isRead());
 	}

--- a/src/test/java/de/thm/arsnova/services/QuestionServiceTest.java
+++ b/src/test/java/de/thm/arsnova/services/QuestionServiceTest.java
@@ -17,10 +17,13 @@
  */
 package de.thm.arsnova.services;
 
-import de.thm.arsnova.dao.StubDatabaseDao;
-import de.thm.arsnova.entities.InterposedQuestion;
-import de.thm.arsnova.entities.Question;
-import de.thm.arsnova.exceptions.NotFoundException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,12 +39,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import de.thm.arsnova.dao.StubDatabaseDao;
+import de.thm.arsnova.entities.InterposedQuestion;
+import de.thm.arsnova.entities.Question;
+import de.thm.arsnova.exceptions.NotFoundException;
+import de.thm.arsnova.repositories.StubInterposedQuestionRepository;
 
 @WebAppConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -61,6 +63,9 @@ public class QuestionServiceTest {
 
 	@Autowired
 	private StubDatabaseDao databaseDao;
+
+	@Autowired
+	private StubInterposedQuestionRepository interposedRepository;
 
 	private void setAuthenticated(final boolean isAuthenticated, final String username) {
 		if (isAuthenticated) {
@@ -108,7 +113,7 @@ public class QuestionServiceTest {
 		theQ.setRead(false);
 		theQ.setId("the internal id");
 		theQ.setSessionId("12345678");
-		databaseDao.interposedQuestion = theQ;
+		interposedRepository.interposedQuestion = theQ;
 
 		questionService.readInterposedQuestion(theQ.getId());
 
@@ -123,7 +128,7 @@ public class QuestionServiceTest {
 		theQ.setId("the internal id");
 		theQ.setSessionId("12345678");
 		theQ.setCreator("regular user");
-		databaseDao.interposedQuestion = theQ;
+		interposedRepository.interposedQuestion = theQ;
 
 		questionService.readInterposedQuestion(theQ.getId());
 

--- a/src/test/resources/test-config.xml
+++ b/src/test/resources/test-config.xml
@@ -11,8 +11,8 @@
 		<property name="databaseDao" ref="databaseDao" />
 	</bean>
 
-	<bean id="databaseDao" class="de.thm.arsnova.dao.StubDatabaseDao">
-	</bean>
+	<bean id="databaseDao" class="de.thm.arsnova.dao.StubDatabaseDao" />
+	<bean id="interposedRepository" class="de.thm.arsnova.repositories.StubInterposedQuestionRepository" />
 
 	<bean id="userService" class="de.thm.arsnova.services.StubUserService" />
 


### PR DESCRIPTION
This is a preview of the upcoming Spring Data and Couchbase integration.

Implementation for interposed questions should be complete. Feel free to ask any questions about the code, e.g., why the `InterposedQuestionRepository` is split between two interfaces: This is because the Couchbase API is in a transition phase from MapReduce Views to N1QL. The repository API does not support complex keys for views any more. At the same time, the N1QL implementation lacks a few features. That is why I resorted to taking a mixed approach, where I use N1QL where possible and fall back to our existing views if the required features are not there yet.

Here is the view code (semantically equivalent to the one we are using in CouchDB):

```javascript
function(doc, meta) {
  if (doc.type === 'interposed_question' || doc._class === 'de.thm.arsnova.entities.InterposedQuestion') {
    emit([doc.sessionId, doc.creator, (doc.read ? 'read' : 'unread')], 1);
  }
}
```
Reduce function is `_count`. Note that this single view is enough to implement that feature. Currently, I count a total of 6 views in CouchDB for interposed questions. These are probably obsolete.

Todos

- [x] Fix test failures
- [ ] Add view update for Couchbase to arsnova-setuptool
- [ ] Migrate data
- [ ] Merge front-end changes (not much has changed, see [here](https://github.com/commana/arsnova-mobile/commit/9bdc52c0f1ff889d1fd298f7dd532e52994ec3ae))

I will update this todo list if need be based on your comments.