### PR TITLE
To prevent address conflicts for Socket.IO use upcounting port offset

### DIFF
--- a/src/main/java/de/thm/arsnova/config/ExtraConfig.java
+++ b/src/main/java/de/thm/arsnova/config/ExtraConfig.java
@@ -62,6 +62,8 @@ public class ExtraConfig extends WebMvcConfigurerAdapter {
 	@Value(value = "${security.keystore}") private String socketKeystore;
 	@Value(value = "${security.storepass}") private String socketStorepass;
 
+	private static int testPortOffset = 0;
+
 	@Bean
 	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
 		final PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
@@ -110,7 +112,7 @@ public class ExtraConfig extends WebMvcConfigurerAdapter {
 	@Profile("test")
 	@Bean(name = "socketServer", initMethod = "startServer", destroyMethod = "stopServer")
 	public ARSnovaSocket socketTestServer() {
-		final int testSocketPort = 1234;
+		final int testSocketPort = 1234 + testPortOffset++ % 10;
 		final ARSnovaSocketIOServer socketServer = new ARSnovaSocketIOServer();
 		socketServer.setHostIp(socketIp);
 		socketServer.setPortNumber(socketPort + testSocketPort);


### PR DESCRIPTION
In some cases the Socket.IO servers used in test cases are not closed
when starting a new test. In this cases the tests will fail with
an address conflict because an other Socket.IO server is still running.

Using a new port, starting with previous defined port 1234 up to 1243 will
assign every new created Socket.IO server an other address/port.

An address conflict will still occure if an other service is running on
ports from 1234 to 1243, so it is generally a bad idea to have tests in the
hope that no side effects will occure from outside of application scope.