### PR TITLE
Show user course sessions

### DIFF
--- a/src/main/java/de/thm/arsnova/controller/CourseController.java
+++ b/src/main/java/de/thm/arsnova/controller/CourseController.java
@@ -56,8 +56,10 @@ public class CourseController extends AbstractController {
 	@RequestMapping(value = "/mycourses", method = RequestMethod.GET)
 	public List<Course> myCourses(
 			@ApiParam(value = "sort my courses by name", required = true)
-			@RequestParam(value = "sortby", defaultValue = "name") final String sortby
-			) {
+			@RequestParam(value = "sortby", defaultValue = "name") final String sortby,
+			@ApiParam(value = "whether to return only courses where user is teacher", required = false)
+			@RequestParam(value = "onlyTeacher", defaultValue = "true") final boolean onlyTeacher
+	) {
 
 		final User currentUser = userService.getCurrentUser();
 
@@ -72,10 +74,8 @@ public class CourseController extends AbstractController {
 		final List<Course> result = new ArrayList<>();
 
 		for (final Course course : connectorClient.getCourses(currentUser.getUsername()).getCourse()) {
-			if (
-					course.getMembership().isMember()
-					&& course.getMembership().getUserrole().equals(UserRole.TEACHER)
-					) {
+			if (course.getMembership().isMember()
+					&& (!onlyTeacher || course.getMembership().getUserrole().equals(UserRole.TEACHER))) {
 				result.add(course);
 			}
 		}

--- a/src/main/java/de/thm/arsnova/controller/SessionController.java
+++ b/src/main/java/de/thm/arsnova/controller/SessionController.java
@@ -215,6 +215,25 @@ public class SessionController extends PaginationController {
 		return sessions;
 	}
 
+	@ApiOperation(value = "Retrieves a list of Sessions that were created for the given courses, "
+			+ "EXCLUDING the sessions the current user created himself or has already visited",
+			nickname = "getSessionsForCourses")
+	@ApiResponses(value = {
+		@ApiResponse(code = 204, message = HTML_STATUS_204)
+	})
+	@RequestMapping(value = "/relevantFromCourse", method = RequestMethod.GET)
+	@Pagination
+	public List<SessionInfo> getUserRelevantSessionsForCourses(
+			@ApiParam(value = "courses", required = true) @RequestParam(value = "courses", defaultValue = "null") int[] courses,
+			final HttpServletResponse response
+			) {
+		if (courses.length == 0) {
+			response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+			return null;
+		}
+		return sessionService.getRelevantCourseSessionsInfo(courses, offset, limit);
+	}
+
 	/**
 	 * Returns a list of my own sessions with only the necessary information like name, keyword, or counters.
 	 */

--- a/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
+++ b/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
@@ -55,23 +55,11 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-<<<<<<< f52814dff8f49a4095b9208bd3a75c7147c764cc
 import java.util.*;
-=======
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
->>>>>>> Show user his course sessions he has not yet visited or did not create
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.logging.Level;
 
 /**
@@ -1695,27 +1683,20 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 			super(fullname);
 		}
 
-<<<<<<< f52814dff8f49a4095b9208bd3a75c7147c764cc
-		void setCourseIdKeys(final List<Course> courses) {
-			List<String> courseIds = new ArrayList<>();
-			for (Course c : courses) {
-				courseIds.add(c.getId());
-=======
 		public void setCourseIdKeys(final int[] courses) {
-			String s = "[";
-			for (int i : courses) {
-				if (s.length() == 1) {
-					s += "\"" + i + "\"";
-				} else {
-					s += ",\"" + i + "\"";
-				}
-			}
-			s += "]";
 			try {
+				String s = "[";
+				for (int i : courses) {
+					if (s.length() == 1) {
+						s += "\"" + i + "\"";
+					} else {
+						s += ",\"" + i + "\"";
+					}
+				}
+				s += "]";
 				this.keys = URLEncoder.encode(s, "UTF-8");
 			} catch (UnsupportedEncodingException ex) {
 				java.util.logging.Logger.getLogger(CouchDBDao.class.getName()).log(Level.SEVERE, null, ex);
->>>>>>> Show user his course sessions he has not yet visited or did not create
 			}
 		}
 

--- a/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
+++ b/src/main/java/de/thm/arsnova/dao/IDatabaseDao.java
@@ -17,7 +17,6 @@
  */
 package de.thm.arsnova.dao;
 
-import de.thm.arsnova.connector.model.Course;
 import de.thm.arsnova.domain.CourseScore;
 import de.thm.arsnova.entities.*;
 import de.thm.arsnova.entities.transport.ImportExportSession;
@@ -165,11 +164,11 @@ public interface IDatabaseDao {
 
 	void deleteInterposedQuestion(InterposedQuestion question);
 
-	List<Session> getCourseSessions(List<Course> courses);
-
 	Session updateSession(Session session);
 
 	Session changeSessionCreator(Session session, String newCreator);
+
+	List<Session> getRelevantCourseSessions(int[] courses, final int start, final int limit, final User currentUser);
 
 	/**
 	 * Deletes a session and related data.
@@ -243,6 +242,10 @@ public interface IDatabaseDao {
 	List<SessionInfo> getMyPublicPoolSessionsInfo(final User user);
 
 	List<SessionInfo> getMyVisitedSessionsInfo(User currentUser, final int start, final int limit);
+
+	List<SessionInfo> getRelevantCourseSessionsInfo(int[] courses, final int start, final int limit, final User currentUser);
+
+	List<Session> getCoursesForSession(final int[] courses, final int start, final int limit);
 
 	int deleteAllPreparationAnswers(Session session);
 

--- a/src/main/java/de/thm/arsnova/services/ISessionService.java
+++ b/src/main/java/de/thm/arsnova/services/ISessionService.java
@@ -52,6 +52,8 @@ public interface ISessionService {
 
 	List<Session> getMyVisitedSessions(int offset, int limit);
 
+	List<Session> getRelevantCourseSessions(final int[] courses, final int start, final int limit);
+
 	int countSessions(List<Course> courses);
 
 	int activeUsers(String sessionkey);
@@ -79,6 +81,8 @@ public interface ISessionService {
 	List<SessionInfo> getMyPublicPoolSessionsInfo();
 
 	List<SessionInfo> getMyVisitedSessionsInfo(int offset, int limit);
+
+	List<SessionInfo> getRelevantCourseSessionsInfo(final int[] courses, final int start, final int limit);
 
 	SessionInfo importSession(ImportExportSession session);
 

--- a/src/main/java/de/thm/arsnova/services/SessionService.java
+++ b/src/main/java/de/thm/arsnova/services/SessionService.java
@@ -270,6 +270,12 @@ public class SessionService implements ISessionService, ApplicationEventPublishe
 
 	@Override
 	@PreAuthorize("isAuthenticated()")
+	public List<SessionInfo> getRelevantCourseSessionsInfo(int[] courses, final int start, final int limit) {
+		return databaseDao.getRelevantCourseSessionsInfo(courses, start, limit, userService.getCurrentUser());
+	}
+
+	@Override
+	@PreAuthorize("isAuthenticated()")
 	public Session saveSession(final Session session) {
 		if (connectorClient != null && session.getCourseId() != null) {
 			if (!connectorClient.getMembership(
@@ -319,11 +325,21 @@ public class SessionService implements ISessionService, ApplicationEventPublishe
 
 	@Override
 	public int countSessions(final List<Course> courses) {
-		final List<Session> sessions = databaseDao.getCourseSessions(courses);
+		int[] ids = new int[courses.size()];
+		for (int i = 0; i < courses.size(); i++) {
+			ids[i] = Integer.valueOf(courses.get(i).getId());
+		}
+		final List<Session> sessions = databaseDao.getCoursesForSession(ids, -1, -1);
 		if (sessions == null) {
 			return 0;
 		}
 		return sessions.size();
+	}
+
+	@Override
+	public List<Session> getRelevantCourseSessions(final int[] courses, final int start, final int limit) {
+		List<Session> moodleCourses = databaseDao.getRelevantCourseSessions(courses, start, limit, userService.getCurrentUser());
+		return moodleCourses;
 	}
 
 	@Override

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -754,4 +754,9 @@ public class StubDatabaseDao implements IDatabaseDao {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+        @Override
+        public List<SessionInfo> getCourseSessionsInfo(List<Course> courses) {
+            return null;
+        }
 }

--- a/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
+++ b/src/test/java/de/thm/arsnova/dao/StubDatabaseDao.java
@@ -334,11 +334,6 @@ public class StubDatabaseDao implements IDatabaseDao {
 	}
 
 	@Override
-	public List<Session> getCourseSessions(List<Course> courses) {
-		return null;
-	}
-
-	@Override
 	public Session updateSession(Session session) {
 		// TODO Auto-generated method stub
 		return null;
@@ -755,8 +750,21 @@ public class StubDatabaseDao implements IDatabaseDao {
 		return null;
 	}
 
-        @Override
-        public List<SessionInfo> getCourseSessionsInfo(List<Course> courses) {
-            return null;
-        }
+	@Override
+	public List<Session> getRelevantCourseSessions(int[] courses, int start, int limit, User currentUser) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<SessionInfo> getRelevantCourseSessionsInfo(int[] courses, int start, int limit, User currentUser) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<Session> getCoursesForSession(int[] courses, int start, int limit) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }


### PR DESCRIPTION
These are the backend changes for this (https://github.com/thm-projects/arsnova-mobile/pull/72) PR. The added features are explained there.

Noteable here is that aside of implementing a new feature there is also a bugfix. It seems that getCourseSessions did not work, because setCourseIdKeys was setting the ids as ints rather than strings. At least it only worked for me that way. A feature that already relied on getCourseSessions  is that if you create multiple sessions for the same LMS course the name of the session will be appended with "(2)" if it is the second session, "(3)" if it is the third and so on. This feature works now as it was supposed to do. However if you create a second session, delete the first one and create another one there will be two sessions with an appended "(2)" as it only takes into account the current number of sessions for that course which might be a little bit confusing.