### PR TITLE
Fix NullPointerException in SessionService.getSessionInternal()

### DIFF
--- a/src/main/java/de/thm/arsnova/services/SessionService.java
+++ b/src/main/java/de/thm/arsnova/services/SessionService.java
@@ -212,7 +212,7 @@ public class SessionService implements ISessionService, ApplicationEventPublishe
 		}
 		if (connectorClient != null && session.isCourseSession()) {
 			final String courseid = session.getCourseId();
-			if (!connectorClient.getMembership(userService.getCurrentUser().getUsername(), courseid).isMember()) {
+			if (!connectorClient.getMembership(user.getUsername(), courseid).isMember()) {
 				throw new ForbiddenException();
 			}
 		}


### PR DESCRIPTION
This PR solves a NullPointerException that was thrown each time when entering a session that was created for a LMS course (at least it did for moodle). The cause is that SecurityContextHolder.getContext().getAuthentication() in UserService.getCurrentUser() is null at that point in time. I'm not enough into ARSnova to assess whether this is a bug or just a matter of timing. So instead of getting the current user the membership is now tested for the given user. I checked all four places in the codebase where getSessionInternal is used and to me it seems that it's totally fine and the intended behaviour to use the user passed to the method. 

As a reference I attached the stack trace of the thrown exception.
[stacktrace_npe.txt](https://github.com/thm-projects/arsnova-backend/files/790227/stacktrace_npe.txt)

