### PR TITLE
Edit lms state of session

### DIFF
--- a/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
+++ b/src/main/java/de/thm/arsnova/dao/CouchDBDao.java
@@ -1675,6 +1675,9 @@ public class CouchDBDao implements IDatabaseDao, ApplicationEventPublisherAware 
 			s.put("name", session.getName());
 			s.put("shortName", session.getShortName());
 			s.put("active", session.isActive());
+			s.put("courseType", session.getCourseType());
+			s.put("courseId", session.getCourseId());
+			s.put("courseSession", session.isCourseSession());
 			s.put("ppAuthorName", session.getPpAuthorName());
 			s.put("ppAuthorMail", session.getPpAuthorMail());
 			s.put("ppUniversity", session.getPpUniversity());

--- a/src/main/java/de/thm/arsnova/services/SessionService.java
+++ b/src/main/java/de/thm/arsnova/services/SessionService.java
@@ -361,6 +361,8 @@ public class SessionService implements ISessionService, ApplicationEventPublishe
 		existingSession.setPpLicense(session.getPpLicense());
 		existingSession.setPpSubject(session.getPpSubject());
 		existingSession.setFeedbackLock(session.getFeedbackLock());
+		existingSession.setCourseId(session.getCourseId());
+		existingSession.setCourseType(session.getCourseType());
 
 		handleLogo(session);
 		existingSession.setPpLogo(session.getPpLogo());

--- a/src/main/java/de/thm/arsnova/services/SessionService.java
+++ b/src/main/java/de/thm/arsnova/services/SessionService.java
@@ -352,7 +352,6 @@ public class SessionService implements ISessionService, ApplicationEventPublishe
 		existingSession.setShortName(session.getShortName());
 		existingSession.setPpAuthorName(session.getPpAuthorName());
 		existingSession.setPpAuthorMail(session.getPpAuthorMail());
-		existingSession.setShortName(session.getShortName());
 		existingSession.setPpAuthorName(session.getPpAuthorName());
 		existingSession.setPpFaculty(session.getPpFaculty());
 		existingSession.setName(session.getName());


### PR DESCRIPTION
These are the backend changes for this PR (https://github.com/thm-projects/arsnova-mobile/pull/76).
Basically this enables a teacher to change the lms course a session is linked with; more details in the other PR.