### PR TITLE
Fixed array index out of bounds error

### DIFF
--- a/src/main/java/de/thm/arsnova/services/SessionServiceImpl.java
+++ b/src/main/java/de/thm/arsnova/services/SessionServiceImpl.java
@@ -190,9 +190,9 @@ public class SessionServiceImpl extends DefaultEntityServiceImpl<Session> implem
 				logger.info("Deleted {} inactive guest sessions.", inactiveSessions.size());
 				dbLogger.log("cleanup", "type", "session",
 						"sessionCount", inactiveSessions.size(),
-						"questionCount", totalCount[1],
-						"answerCount", totalCount[2],
-						"commentCount", totalCount[3]);
+						"questionCount", totalCount[0],
+						"answerCount", totalCount[1],
+						"commentCount", totalCount[2]);
 			}
 		}
 	}


### PR DESCRIPTION
Since array should contain (see: deleteCascading(final Session session)):
0 => content (aka question)
1 => answer
2 => comment
same index should be used for logging. Accessing index 1,2 and 3 will
cause an index out of bound error.