### PR TITLE
Fixed granted authority check in unsued websocket access check method

### DIFF
--- a/src/main/java/de/thm/arsnova/security/ApplicationPermissionEvaluator.java
+++ b/src/main/java/de/thm/arsnova/security/ApplicationPermissionEvaluator.java
@@ -199,6 +199,11 @@ public class ApplicationPermissionEvaluator implements PermissionEvaluator {
 	}
 
 	private boolean isWebsocketAccess(Authentication auth) {
-		return auth instanceof AnonymousAuthenticationToken && auth.getAuthorities().contains("ROLE_WEBSOCKET_ACCESS");
+		return auth instanceof AnonymousAuthenticationToken
+				&& auth.getAuthorities().stream()
+				.anyMatch(
+						grantedAuthority ->
+						grantedAuthority.getAuthority().equals("ROLE_WEBSOCKET_ACCESS")
+						);
 	}
 }


### PR DESCRIPTION
Even if this method is not used in any way, the correct check for the
authoritys name should be made using getAuthority() for each
granted authority, which will return the authoritys name.