### PR TITLE
Several fixes in source code

### DIFF
--- a/src/main/java/de/thm/arsnova/config/AppConfig.java
+++ b/src/main/java/de/thm/arsnova/config/AppConfig.java
@@ -29,7 +29,7 @@ import de.thm.arsnova.websocket.ArsnovaSocketioServer;
 import de.thm.arsnova.websocket.ArsnovaSocketioServerImpl;
 import de.thm.arsnova.websocket.ArsnovaSocketioServerListener;
 import de.thm.arsnova.web.CacheControlInterceptorHandler;
-import de.thm.arsnova.web.CorsFilter;
+import de.thm.arsnova.web.CustomCorsFilter;
 import de.thm.arsnova.web.DeprecatedApiInterceptorHandler;
 import de.thm.arsnova.web.ResponseInterceptorHandler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -233,8 +233,8 @@ public class AppConfig extends WebMvcConfigurerAdapter {
 	}
 
 	@Bean
-	public CorsFilter corsFilter() {
-		return new CorsFilter(Arrays.asList(corsOrigins));
+	public CustomCorsFilter corsFilter() {
+		return new CustomCorsFilter(Arrays.asList(corsOrigins));
 	}
 
 	@Bean(name = "connectorClient")

--- a/src/main/java/de/thm/arsnova/util/ImageUtils.java
+++ b/src/main/java/de/thm/arsnova/util/ImageUtils.java
@@ -230,11 +230,9 @@ public class ImageUtils {
 	 * @return The <code>byte[]</code> of the image on success, otherwise <code>null</code>.
 	 */
 	byte[] convertFileToByteArray(final String imageUrl) {
-		try {
-			final URL url = new URL(imageUrl);
+		try (InputStream is = new URL(imageUrl).openStream()) {
 			final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-			final InputStream is = url.openStream();
 			final byte[] byteChunk = new byte[CHUNK_SIZE];
 			int n;
 

--- a/src/main/java/de/thm/arsnova/util/ImageUtils.java
+++ b/src/main/java/de/thm/arsnova/util/ImageUtils.java
@@ -81,7 +81,7 @@ public class ImageUtils {
 		if (urlParts.length > 0) {
 			final String extension = urlParts[urlParts.length - 1];
 
-			return "data:image/" + extension + ";base64," + Base64.encodeBase64String(convertFileToByteArray(imageUrl));
+			return IMAGE_PREFIX_START + extension + IMAGE_PREFIX_MIDDLE + Base64.encodeBase64String(convertFileToByteArray(imageUrl));
 		}
 
 		return null;
@@ -186,9 +186,9 @@ public class ImageUtils {
 				g.dispose();
 
 				StringBuilder result = new StringBuilder();
-				result.append("data:image/");
+				result.append(IMAGE_PREFIX_START);
 				result.append(extension);
-				result.append(";base64,");
+				result.append(IMAGE_PREFIX_MIDDLE);
 
 				ByteArrayOutputStream output = new ByteArrayOutputStream();
 				ImageIO.write(newImage, extension, output);

--- a/src/main/java/de/thm/arsnova/web/CustomCorsFilter.java
+++ b/src/main/java/de/thm/arsnova/web/CustomCorsFilter.java
@@ -21,15 +21,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
 
-public class CorsFilter extends org.springframework.web.filter.CorsFilter {
-	private final Logger logger = LoggerFactory.getLogger(CorsFilter.class);
+public class CustomCorsFilter extends CorsFilter {
+	private final Logger log = LoggerFactory.getLogger(CustomCorsFilter.class);
 
-	public CorsFilter(List<String> origins) {
+	public CustomCorsFilter(List<String> origins) {
 		super(configurationSource(origins));
-		logger.info("CorsFilter initialized. Allowed origins: {}", origins);
+		log.info("CorsFilter initialized. Allowed origins: {}", origins);
 	}
 
 	private static UrlBasedCorsConfigurationSource configurationSource(List<String> origins) {


### PR DESCRIPTION
This set of patches includes several fixes for ARSnova backend.

`ImageUtils`:
* Use try-with-resource statement to close stream on exception 
* Use already defined constants instead of strings 

Renamed `CorsFilter` to `CustomCorsFilter` since parent class from Spring has the same name. Since base class already has a logger with same name but different interface, renamed logger variable to `log`.
