### PR TITLE
Use Spring Boot 2.0.6 with maven plugin and dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,10 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<io.spring.platform-version>Cairo-SR5</io.spring.platform-version>
+		<spring-boot-version>2.0.6.RELEASE</spring-boot-version>
+		<commons-lang-version>2.6</commons-lang-version>
+		<guava-version>20.0</guava-version>
+		<directory-server-version>1.5.5</directory-server-version>
 		<io.netty-version>4.1.30.Final</io.netty-version>
 		<org.aspectj-version>1.8.13</org.aspectj-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -74,6 +77,10 @@
 				<version>3.0.1</version>
 				<configuration></configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</reporting>
 
@@ -122,9 +129,10 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>io.spring.platform</groupId>
-				<artifactId>platform-bom</artifactId>
-				<version>${io.spring.platform-version}</version>
+				<!-- Import dependency management from Spring Boot -->
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot-version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -142,6 +150,7 @@
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
+			<version>${commons-lang-version}</version>
 		</dependency>
 		<!-- Spring -->
 		<dependency>
@@ -188,6 +197,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+			<version>${guava-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -223,7 +233,6 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>javax.mail</artifactId>
-			<version>1.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -259,6 +268,7 @@
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
 			<scope>test</scope>
+			<version>1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -304,11 +314,13 @@
 		<dependency>
 			<groupId>org.apache.directory.server</groupId>
 			<artifactId>apacheds-core</artifactId>
+			<version>${directory-server-version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.directory.server</groupId>
 			<artifactId>apacheds-server-jndi</artifactId>
+			<version>${directory-server-version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Since Spring IO Platform will reach end of life in April 2019, users are encouraged to use Spring Boot dependency management system (see: https://spring.io/projects/platform).

Spring boot 2.0.6.RELEASE was used to have closest match of version related to Spring IO Cairo-SR5.

Missing dependency versions from Spring IO Platform BOM are added as properties.